### PR TITLE
Fixed: Collapse button arrow points right when sidebar is collapsed

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -141,3 +141,7 @@
     display: flex;
   }
 }
+
+.flipIconVertical > button > img {
+  rotate: (180deg);
+}

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -82,7 +82,10 @@ export function SidebarNavigation() {
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
-              className={styles.collapseMenuItem}
+              className={classNames(
+                styles.collapseMenuItem,
+                isSidebarCollapsed && styles.flipIconVertical,
+              )}
             />
           </ul>
         </nav>


### PR DESCRIPTION
- Adjusted the behavior of the Collapse button to ensure that its arrow icon points to the right when the sidebar navigation is collapsed.